### PR TITLE
Removing Java EE dependencies in favor of Jakarta EE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <dockerImageName>quickstarter/openshift-kie-springboot</dockerImageName>
     <failOnMissingWebXml>false</failOnMissingWebXml>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <version.annotations>2.0.1.Final</version.annotations>
+    <version.annotations>1.3.5</version.annotations>
     <version.fabric8.plugin>4.2.0</version.fabric8.plugin>
     <version.fabric8.docker-plugin>0.30.0</version.fabric8.docker-plugin>
     <surefire.forkCount>1</surefire.forkCount>
@@ -174,8 +174,8 @@
       </dependency>
 
       <dependency>
-        <groupId>org.jboss.spec.javax.annotation</groupId>
-        <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+        <groupId>jakarta.annotation</groupId>
+        <artifactId>jakarta.annotation-api</artifactId>
         <version>${version.annotations}</version>
         <scope>compile</scope>
       </dependency>

--- a/springboot/pom.xml
+++ b/springboot/pom.xml
@@ -71,8 +71,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jboss.spec.javax.annotation</groupId>
-      <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
       <scope>compile</scope>
     </dependency>
 


### PR DESCRIPTION
https://github.com/errai/errai/pull/433
https://github.com/jesuino/droolsjbpm-build-bootstrap/pull/1
https://github.com/jesuino/kie-soup/pull/1
https://github.com/jesuino/droolsjbpm-knowledge/pull/1
https://github.com/jesuino/drools/pull/1
https://github.com/jesuino/optaplanner/pull/1
https://github.com/jesuino/appformer/pull/1
https://github.com/jesuino/kie-uberfire-extensions/pull/1
https://github.com/jesuino/jbpm/pull/1
https://github.com/jesuino/kie-jpmml-integration/pull/1
https://github.com/jesuino/droolsjbpm-integration/pull/1
https://github.com/jesuino/kie-wb-playground/pull/1
https://github.com/jesuino/kie-wb-common/pull/2
https://github.com/jesuino/drools-wb/pull/1
https://github.com/jesuino/jbpm-designer/pull/1
https://github.com/jesuino/jbpm-work-items/pull/2
https://github.com/jesuino/jbpm-wb/pull/1
https://github.com/jesuino/optaplanner-wb/pull/1
https://github.com/jesuino/kie-wb-distributions/pull/3
https://github.com/jesuino/openshift-drools-hacep/pull/1
https://github.com/jesuino/process-migration-service/pull/1
https://github.com/jesuino/optaweb-employee-rostering/pull/1